### PR TITLE
Update runtime node version

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,7 @@ service: ssr-react-next
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs12.x
   stage: ${self:custom.secrets.NODE_ENV}
   region: us-east-1
   environment: 


### PR DESCRIPTION
nodejs8.10 is no longer supported for creating or updating AWS Lambda functions. It is recommended to use the new runtime (nodejs12.x) while creating or updating functions.